### PR TITLE
Changing el-get.git url to avoid error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,4 +54,4 @@
 	url = git://github.com/kiwanami/emacs-deferred.git
 [submodule ".emacs.d/plugins/el-get"]
 	path = .emacs.d/plugins/el-get
-	url = git@github.com:dimitri/el-get.git
+	url = https://github.com/dimitri/el-get.git


### PR DESCRIPTION
git submodule init; git submodule update . reported an error while running el-get.git module, this should fix it.
