### PR TITLE
Exit bootstrap.sh if git exit code is other than 0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,11 @@
 cd "$(dirname "${BASH_SOURCE}")"
 git pull origin master
 
+gitExitCode=$?
+if [[ $gitExitCode != 0 ]]; then
+    exit $gitExitCode
+fi
+
 function clean() {
         git clean -nx
 	read -p "Clean the above files? (y/n) " -n 1


### PR DESCRIPTION
If git pull fails, then bootstrap should fail with the same exit code.

Currently, if git pull fails, bootstrap.sh continues asking user for input.