### PR TITLE
Fix launch failure with updated solarized theme

### DIFF
--- a/.emacs.d/settings/custom.el
+++ b/.emacs.d/settings/custom.el
@@ -8,7 +8,7 @@
 
 ; color theme
 (add-to-list 'custom-theme-load-path (make-plugin-path "color-theme-solarized"))
-(load-theme 'solarized-dark 1)
+(load-theme 'solarized 1)
 (setq solarized-termcolors 256)
 
 (require 'faces)


### PR DESCRIPTION
An update to solarized has broken this emacs setup by removing support for the separate solarized-light and solarized-dark themes.