### PR TITLE
Change path for nxhtml/autostart.el

### DIFF
--- a/.emacs.d/settings/mumamo-settings.el
+++ b/.emacs.d/settings/mumamo-settings.el
@@ -2,7 +2,7 @@
 ;;; MuMaMo / nxhtml ;;;
 ;---------------------;
 
-(load (make-plugin-path "nxhtml/autostart.el"))
+(load (make-plugin-path "nxhtml/elisp/autostart.el"))
 ;; Workaround the annoying warnings:
 ;;    Warning (mumamo-per-buffer-local-vars):
 ;;    Already 'permanent-local t: buffer-file-name


### PR DESCRIPTION
Hi,

I had a problem with the installation, because the file `nxhtml/autostart.el` loaded by `mumamo-settings.el` wasn't found. On my installation, I saw that the file was in `nxhtml/elisp/autostart.el` , so I changed the path.

I don't understand the problem, because according to the documentation, this file should be in `nxhtml/autostart.el`. Maybe it is a version problem.

I am using Emacs 24.5.1 on a Ubuntu 15.10, and I started my emacs installation from scratch with your script, on a new computer.

