### PR TITLE
Fix gcp: command not found error

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,7 +25,7 @@ function doIt() {
 	if [ $i != '.' -a $i != '..' -a $i != '.git' -a $i != '.DS_Store' -a $i != 'bootstrap.sh' -a $i != 'README.md' -a $i != '.gitignore' -a $i != '.gitmodules' ]; then 
             if [ $(uname) == "Darwin" ]; then
 	        echo "$i"
-	        gcp -alrf "$i" "$HOME/"
+                cp -af "$i" "$HOME/"
             else
                 echo "$i"
                 cp -alrf "$i" "$HOME/"


### PR DESCRIPTION
Some minor correction. I got errors about gcp command not found running bootstrap.sh on my Macbook Air running Yosemite. I think gcp was a typo. I also got errors about -l not being a valid command option for cp under Mac OS X but is valid for Linux. The -r option is already accounted for by the -a option.