### PR TITLE
Add gotcha info about auto-complete minor mode disappearing from pyth…

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,12 @@ integration". Otherwise, read on.
 ### Tramp is timing out
 
 If you get the error `tramp ssh: connect to host c port 22: Operation timed out` and you are running OS X Mavericks with Emacs installed using Homebrew, then this is probably due to the Mavericks upgrade. Try reinstalling Emacs through Homebrew and remove the folder `~/.emacs.d/el-get` (note: this will remove all your el-get plugins, and they will need to be reinstalled).
+
+### Auto-complete disappears from python mode
+The python mode needs to have the `jedi`, `epc`, and `pylint` packages added to your Python installation. Run this command:
+
+  ```
+  pip install jedi epc pylint
+  ```
+
+Hint provided by Andrea Crotti's EuroPython 2013 Conference talk, [Emacs and shell as your best friends](https://www.youtube.com/watch?v=0cZ7szFuz18), and the [minimal Emacs configuration](https://github.com/AndreaCrotti/minimal-emacs-configuration) used in the talk.


### PR DESCRIPTION
…on mode

I've been trying various people's emacs setups. Your's along with your blog posts have been very accessible for me getting back into using Emacs after many years of Vim use. I wasn't puzzled when I tried to edit a Python script and had the auto-complete not work. The initial load of the file showed the auto-complete minor mode with the python mode but as soon as I typed something the auto-complete mode indication disappeared. After watching Andrea Crotti's EuroPython 2013 talk I realized that I hadn't installed the required Python packages. After doing so, python mode worked well with the pop-up list of suggestions as I typed. I added to the Gotchas section in case others might miss that as a required step for getting things to work.